### PR TITLE
this[key] was not actually correctly assigning anything

### DIFF
--- a/src/graffiti/private/utils/meta.js
+++ b/src/graffiti/private/utils/meta.js
@@ -6,6 +6,7 @@ export default class Meta {
   isCheckingAttributes = false;
   pendingAttributeChangeCount = 0;
   zone = null;
+  descriptors = {};
 
   constructor() {
     seal(this);

--- a/test/unit/graffiti/decorators/reflectToAttribute.spec.js
+++ b/test/unit/graffiti/decorators/reflectToAttribute.spec.js
@@ -2,6 +2,8 @@ import { expect } from 'chai';
 import reflectToAttribute from '../../../../src/graffiti/decorators/reflectToAttribute';
 import { spy } from 'sinon';
 
+var initializerCallCount = 0;
+
 class MockHTMLElement {
   constructor() {
     this.setAttribute = spy();
@@ -11,30 +13,38 @@ class MockHTMLElement {
 
 class MyCounterComponent extends MockHTMLElement {
   @reflectToAttribute()
-  counter = 0;
+  counter = (function () {
+    initializerCallCount++;
+    return 0
+  })();
 
   events = {
     increment() {
       this.counter++;
-      console.log(this.counter);
     }
   }
 }
 
-describe('reflectToAttribute', () => {
-  it('should set the correct value for the given key', () => {
-    var cc = new MyCounterComponent();
-    expect(cc.counter).to.equal(0);
+describe('reflectToAttribute', function () {
+  afterEach(function () {
+    initializerCallCount = 0;
   });
 
-  it('should set attribute', function() {
+  it('should set the correct value for the given key', function () {
+    var cc = new MyCounterComponent();
+    expect(cc.counter).to.equal(0);
+    expect(initializerCallCount).to.equal(1);
+  });
+
+  it('should set attribute', function () {
     var cc = new MyCounterComponent();
     cc.events.increment.bind(cc)();
     expect(cc.counter).to.equal(1);
     expect(cc.setAttribute.calledWith('counter', '1')).to.be.true;
+    expect(initializerCallCount).to.equal(1);
   });
 
-  it('should set values independently for separate component instances', function() {
+  it('should set values independently for separate component instances', function () {
     var cc1 = new MyCounterComponent();
     var cc2 = new MyCounterComponent();
     expect(cc1.counter).to.equal(0);
@@ -42,12 +52,14 @@ describe('reflectToAttribute', () => {
     cc2.events.increment.bind(cc2)();
     expect(cc2.counter).to.equal(2);
     expect(cc1.counter).to.equal(0);
+    expect(initializerCallCount).to.equal(2);
   });
 
-  it('should remove attribute for an undefined value', function() {
+  it('should remove attribute for an undefined value', function () {
     var cc = new MyCounterComponent();
     cc.counter = undefined;
     expect(cc.removeAttribute.calledWith('counter')).to.be.true;
+    expect(initializerCallCount).to.equal(0);
   });
 
 });


### PR DESCRIPTION
`key` was actually undefined, likely because of spec compliancy changes to babel. If it was defined, (like if you just corrected that part) it would cause infinite recursion since that would reference the same descriptor.

Instead I moved the backing storage of the values to a new descriptor meta, inside the instance meta. (lolwut :frowning:).
